### PR TITLE
delay_while_idle fix

### DIFF
--- a/lib/higcm/sender.rb
+++ b/lib/higcm/sender.rb
@@ -10,7 +10,7 @@ module HiGCM
       OPTIONAL_OPTIONS = {
         :collapse_key     => String, 
         :data             => Hash, 
-        :delay_while_idle => Fixnum, 
+        :delay_while_idle => Boolean, 
         :time_to_live     => Fixnum
       }
 


### PR DESCRIPTION
According GCM documentation in JSON format delay_while_idle must be a JSON boolean value
